### PR TITLE
Add schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -60,7 +60,7 @@ model Assignment {
 
   urgency Urgency
 
-  // Use enum for timeslot?
+  // TODO: Use enum for timeslot?
   // timeslot String
 
   assigned Boolean @default(false)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,8 +10,103 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model User {
-  id    String @id @default(uuid())
-  email String @unique
-  name  String
+model Tutor {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  name     String
+  email    String  @unique
+  year     Int
+  nusnetId String?
+  gmail    String?
+  telegram String?
+
+  // A tutor can have many assignments
+  assignments Assignment[]
+
+  // A tutor teaches(?) many modules
+  modules Module[]
+}
+
+model Module {
+  code      String   @id
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  title       String
+  searchQuery String
+
+  // Module in assignments
+  assignments Assignment[]
+
+  // Tutors who teach(?) this module
+  Tutor   Tutor?  @relation(fields: [tutorId], references: [id])
+  tutorId String?
+}
+
+model Assignment {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  // Each Assignment linked to one tutor
+  tutor   Tutor  @relation(fields: [tutorId], references: [id])
+  tutorId String
+
+  // Each assingment is linked to one module
+  module     Module @relation(fields: [moduleCode], references: [code])
+  moduleCode String
+
+  urgency Urgency
+
+  // Use enum for timeslot?
+  // timeslot String
+
+  assigned Boolean @default(false)
+
+  reviewCompleted String?
+  reviewFormUrl   String?
+
+
+  // This assignment's reviews
+  reviews Review[]
+
+  // Transaction linked to this assignment
+  transaction Transaction?
+}
+
+model Review {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  rating   Int?
+  comments String?
+
+  assignment Assignment @relation(fields: [assignmentId], references: [id])
+
+  shareTestimonal Boolean @default(false)
+  assignmentId    String
+}
+
+model Transaction {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  assignment   Assignment @relation(fields: [assignmentId], references: [id])
+  assignmentId String     @unique
+
+  // TODO: need date if we have createdAt?
+
+  // TODO: Default to zero?
+  revenue    Int
+  ourRevenue Int
+}
+
+enum Urgency {
+  oneDay
+  threeDay
+  fiveDay
 }


### PR DESCRIPTION
I tried to copy what was already there on [the airtable table](https://airtable.com/app3j0M6IJ4fqcEoe/tblsKwPMGPuqwqtVi/viw1dn5Cobt5UF2UH?blocks=hide).

See the schema: https://github.com/ninest/ourfinals/blob/schema/prisma/schema.prisma

- What do you think is the best way to store the time slot? It seems we have to store time but not datetime. Perhaps an enum?
- Do any fields have initial values? 

Relevant documentation:

- Prisma schema: https://www.prisma.io/docs/concepts/components/prisma-schema
- Data model: https://www.prisma.io/docs/concepts/components/prisma-schema/data-model
- Relations: https://www.prisma.io/docs/concepts/components/prisma-schema/relations